### PR TITLE
minuitwrp: pixelflinger no longer has VectorImpl

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -156,7 +156,7 @@ else
 endif
 
 LOCAL_CFLAGS += -DTWRES=\"$(TWRES_PATH)\"
-LOCAL_SHARED_LIBRARIES += libz libc libcutils libjpeg libpng
+LOCAL_SHARED_LIBRARIES += libz libc libcutils libjpeg libpng libutils
 LOCAL_STATIC_LIBRARIES += libpixelflinger_static
 LOCAL_MODULE_TAGS := eng
 LOCAL_MODULE := libminuitwrp


### PR DESCRIPTION
after latest google CVE. So add libutils

Change-Id: I86e0c8a23018fae1c4097a9993c8fa7dbbb7c64e